### PR TITLE
Fixed syntax error in setup script

### DIFF
--- a/src/main/scripts/setup_umea_in_storr.sh
+++ b/src/main/scripts/setup_umea_in_storr.sh
@@ -38,12 +38,12 @@ echo "Setup: Creating indices..."
 java -cp $JAR_PATH uk.ac.standrews.cs.data.umea.store.CreateIndices &
 JAVA_PID=$!
 wait "$JAVA_PID"
-JAVA_PID="
+JAVA_PID=""
 
 echo "Setup: Loading event records..."
 java -cp $JAR_PATH uk.ac.standrews.cs.data.umea.store.ImportUmeaRecordsToStore &
 JAVA_PID=$!
 wait "$JAVA_PID"
-JAVA_PID="
+JAVA_PID=""
 
 echo "Setup complete!"


### PR DESCRIPTION
Fixed syntax error in `setup_umea_in_storr.sh` which was introduced in the Interrupt handling commit (and broke the container).