### PR TITLE
Clarify container naming in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,8 @@ COPY data-umea-1.0-SNAPSHOT-jar-with-dependencies.jar ./data-umea.jar
 COPY src ./src
 COPY docker/entrypoint.sh .
 
+# Ports which should be bound when running
+EXPOSE 7474
+EXPOSE 7687
+
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ Where:
 - `--rm` - instructs to remove the container files after container finishes running.
 - `--network umea-neo4j-net` - makes the container accessible on the `umea-neo4j-net` Docker network.
 - `--name umea-neo4j` - sets name of container to `umea-neo4j`
-    - Note: If using with the [population-linkage repository](https://github.com/stacs-srg/population-linkage), you will need to pass the name of this container as an environment variable to the population-linkage container.
+    - Note: If using with the [population-linkage repository](https://github.com/stacs-srg/population-linkage), this will by default expect the name to be `umea-neo4j`. If you change this, you'll need to pass the name of this container as an environment variable to the population-linkage container.
 - Assumes your RSA encrypted PEM private key is installed in the default ssh directory (`~/.ssh`).


### PR DESCRIPTION
Clarifies container naming, with reference to the population-linkage repository in the README. Also adds "EXPOSE x" to Dockerfile for Neo4J ports, to clearly indicate which ports should be bound.